### PR TITLE
Update to amazon-kinesis-connectors 1.1.2 from maven

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "amazon-kinesis-connectors"]
-	path = amazon-kinesis-connectors
-	url = https://github.com/awslabs/amazon-kinesis-connectors.git

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Application for copying Amazon Kinesis data to S3.
 
 ## Development
 
-Checkout the source using Git. Initialize the `amazon-kinesis-connectors` submodule using `git submodule update --init --recursive`
-
 The main class is `com.github.codeflows.aws.KinesisToS3`
 
 ### Building

--- a/pom.xml
+++ b/pom.xml
@@ -11,20 +11,9 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.8.9.1</version>
+            <artifactId>amazon-kinesis-connectors</artifactId>
+            <version>1.1.2</version>
         </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>amazon-kinesis-client</artifactId>
-            <version>1.1.0</version>
-        </dependency>
-        <!--
-          Also depends on amazon-kinesis-connectors, which is not available as a Maven dependency:
-          https://github.com/awslabs/amazon-kinesis-connectors/pull/11
-
-          Instead we include it as a git submodule.
-        -->
     </dependencies>
 
     <build>
@@ -37,24 +26,6 @@
                     <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
-            </plugin>
-            <!-- Add kinesis-connectors sources from the git submodule -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>amazon-kinesis-connectors/src/main/java</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <!-- Build an executable jar -->
             <plugin>


### PR DESCRIPTION
As of [27 May 15](https://github.com/awslabs/amazon-kinesis-connectors#release-112-may-27-2015) `amazon-kinesis-connectors` can be installed using maven instead of git sub module.
